### PR TITLE
Fix live search functionality for grok

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,19 @@
-# xAI API Configuration for Grok 4
-XAI_API_KEY=your_xai_api_key_here
+# xAI API Configuration
+# Get your API key from https://console.x.ai
+XAI_API_KEY=xai-your_xai_api_key_here
 XAI_BASE_URL=https://api.x.ai/v1
 
-# Optional: Grok model configuration
-GROK_MODEL=grok-4
+# Grok Model Configuration
+# Use grok-4.1-fast for optimal performance with integrated live search
+# Available models: grok-4.1-fast, grok-4, grok-4-1-fast-reasoning, grok-4-1-fast-non-reasoning, grok-code-fast-1
+GROK_MODEL=grok-4.1-fast
 GROK_TEMPERATURE=0.7
 GROK_MAX_TOKENS=4000
 
 # MCP Server Configuration
 MCP_SERVER_NAME=grok-4-mcp-server
 MCP_SERVER_VERSION=1.0.0
+
+# Logging Configuration
+LOG_LEVEL=info
+NODE_ENV=production

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ for (const envVar of requiredEnvVars) {
 const grokConfig: GrokConfig = {
   apiKey: process.env.XAI_API_KEY!,
   baseUrl: process.env.XAI_BASE_URL || 'https://api.x.ai/v1',
-  model: process.env.GROK_MODEL || 'grok-4-1-fast-reasoning',
+  model: process.env.GROK_MODEL || 'grok-4.1-fast',
   temperature: parseFloat(process.env.GROK_TEMPERATURE || '0.7'),
   maxTokens: parseInt(process.env.GROK_MAX_TOKENS || '4000'),
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,15 @@ export interface GrokMessage {
   content: string;
 }
 
+export interface SearchParameters {
+  mode?: 'auto' | 'always' | 'never';
+  return_citations?: boolean;
+  sources?: Array<'web' | 'news' | 'x' | 'rss'>;
+  from_date?: string;
+  to_date?: string;
+  included_x_handles?: string[];
+}
+
 export interface GrokChatRequest {
   model: string;
   messages: GrokMessage[];
@@ -11,6 +20,7 @@ export interface GrokChatRequest {
   stream?: boolean;
   functions?: GrokFunction[];
   function_call?: string | { name: string };
+  search_parameters?: SearchParameters;
 }
 
 export interface GrokChatResponse {
@@ -27,6 +37,7 @@ export interface GrokChatResponse {
         name: string;
         arguments: string;
       };
+      citations?: string[];
     };
     finish_reason: string;
   }>;


### PR DESCRIPTION
…ed chat completions

Replace the non-existent /search endpoint with xAI's integrated agentic search in chat completions (post-Nov 2025 migration). Key changes:

- Add SearchParameters type to support search_parameters in chat requests
- Update GrokChatResponse to include citations field from API
- Refactor liveSearch() to use chat completions with search_parameters instead of calling a non-existent /search endpoint
- Update ask() method to pass search_parameters to chat completions when include_search is requested, eliminating separate search API calls
- Replace simulateSearch() fallback with parseSearchResults() that extracts real citations from chat responses
- Update default model to grok-4.1-fast (optimized for agents with 256K context)
- Add comments and logging for new approach
- Update .env.example with clearer documentation

This fixes the root cause of live search failures where the old standalone Live Search API is being deprecated, with all functionality now available through integrated agentic search in chat completions.